### PR TITLE
Add validation if card number is undefined

### DIFF
--- a/custom/fg_custom/static/src/pos/js/FgPosAddPaymentDetails.js
+++ b/custom/fg_custom/static/src/pos/js/FgPosAddPaymentDetails.js
@@ -58,7 +58,7 @@ odoo.define('fg_custom.FgPosAddPaymentDetails', function (require) {
             paymentlines.x_gc_voucher_name= this.x_gc_voucher_name;
             paymentlines.x_gc_voucher_cust= this.x_gc_voucher_cust;
 
-            if(this.x_card_number!=null || this.x_card_number != ''){
+            if(this.x_card_number!=null && this.x_card_number != '' && this.x_card_number){
                 var cardNumberLast4Digits = this.x_card_number.substring(this.x_card_number.length - 4)
                 var mask='';
                 for(var i=0; i< this.x_card_number.length-4; i++ ){


### PR DESCRIPTION
Add validation if card number is undefined

Description of the issue/feature this PR addresses:

Current behavior before PR:  

Desired behavior after PR is merged: error if other payment methods will be selected




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
