### PR TITLE
add margin/padding for receipt sent via email

### DIFF
--- a/custom/fg_custom/static/src/pos/css/fg_custom.css
+++ b/custom/fg_custom/static/src/pos/css/fg_custom.css
@@ -54,3 +54,9 @@
     text-align: center;
     padding-left: 5px;
 }
+
+.pos-receipt{
+    padding-bottom: 18px;
+    padding-left: 18px;
+    padding-right: 18px;
+}


### PR DESCRIPTION
Description of the issue/feature this PR addresses: add margin/padding for receipt sent via email

Current behavior before PR: no margin

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
