### PR TITLE
update css for close-pos-popup to adjust the window

### DIFF
--- a/custom/fg_custom/static/src/pos/css/fg_custom.css
+++ b/custom/fg_custom/static/src/pos/css/fg_custom.css
@@ -60,3 +60,8 @@
     padding-left: 18px;
     padding-right: 18px;
 }
+
+.pos .close-pos-popup{
+    max-width: 800px;
+    max-height: 1000px;
+}


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
  -  pos close popup buttons are not visible
Current behavior before PR:
  - pos close popup buttons are not visible

Desired behavior after PR is merged:
  - update css for close-pos-popup to adjust the window



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
