### PR TITLE
handle duplicate creation of Product

### DIFF
--- a/addons/web/static/src/core/errors/error_handlers.js
+++ b/addons/web/static/src/core/errors/error_handlers.js
@@ -97,6 +97,12 @@ export function rpcErrorHandler(env, error, originalError) {
                 ErrorComponent = errorDialogRegistry.get(exceptionName);
             }
         }
+        if (!ErrorComponent && originalError.data.context) {
+            const exceptionClass = originalError.data.context.exception_class;
+            if (errorDialogRegistry.contains(exceptionClass)) {
+                ErrorComponent = errorDialogRegistry.get(exceptionClass);
+            }
+        }
 
         env.services.dialog.add(ErrorComponent || RPCErrorDialog, {
             traceback: error.traceback,

--- a/addons/web/static/src/core/network/rpc_service.js
+++ b/addons/web/static/src/core/network/rpc_service.js
@@ -31,7 +31,8 @@ export function makeErrorFromResponse(reponse) {
     const { code, data: errorData, message, type: subType } = reponse;
     const { context: data_context, name: data_name } = errorData || {};
     const { exception_class } = data_context || {};
-    const exception_class_name = exception_class || data_name;
+//    const exception_class_name = exception_class || data_name;
+    const exception_class_name = data_name !== 'odoo.exceptions.UserError' ? exception_class || data_name : data_name;
     const error = new RPCError();
     error.exceptionName = exception_class_name;
     error.subType = subType;

--- a/addons/web/static/tests/core/errors/error_service_tests.js
+++ b/addons/web/static/tests/core/errors/error_service_tests.js
@@ -1,5 +1,4 @@
-/** @odoo-module **/
-
+	/** @odoo-module **/
 import { browser } from "@web/core/browser/browser";
 import { dialogService } from "@web/core/dialog/dialog_service";
 import {
@@ -20,15 +19,12 @@ import {
     makeFakeRPCService,
 } from "../../helpers/mock_services";
 import { makeDeferred, nextTick, patchWithCleanup } from "../../helpers/utils";
-
 const { Component, tags } = owl;
 const errorDialogRegistry = registry.category("error_dialogs");
 const errorHandlerRegistry = registry.category("error_handlers");
 const serviceRegistry = registry.category("services");
-
 let errorCb;
 let unhandledRejectionCb;
-
 QUnit.module("Error Service", {
     async beforeEach() {
         serviceRegistry.add("error", errorService);
@@ -50,7 +46,6 @@ QUnit.module("Error Service", {
         });
     },
 });
-
 QUnit.test("handle RPC_ERROR of type='server' and no associated dialog class", async (assert) => {
     assert.expect(2);
     const error = new RPCError();
@@ -81,6 +76,7 @@ QUnit.test("handle RPC_ERROR of type='server' and no associated dialog class", a
 
 QUnit.test(
     "handle RPC_ERROR of type='server' and associated custom dialog class",
+    "handle custom RPC_ERROR of type='server' and associated custom dialog class",
     async (assert) => {
         assert.expect(2);
         class CustomDialog extends Component {}
@@ -90,6 +86,11 @@ QUnit.test(
         error.code = 701;
         error.message = "Some strange error occured";
         error.exceptionName = "strange_error";
+        const errorData = {
+            context: { exception_class: "strange_error" },
+            name: "strange_error",
+        };
+        error.data = errorData;
         function addDialog(dialogClass, props) {
             assert.strictEqual(dialogClass, CustomDialog);
             assert.deepEqual(props, {
@@ -97,9 +98,11 @@ QUnit.test(
                 type: "server",
                 code: 701,
                 data: null,
+                data: errorData,
                 subType: null,
                 message: "Some strange error occured",
                 exceptionName: "strange_error",
+                exceptionName: null,
                 traceback: error.stack,
             });
         }
@@ -111,6 +114,45 @@ QUnit.test(
     }
 );
 
+QUnit.test(
+    "handle normal RPC_ERROR of type='server' and associated custom dialog class",
+    async (assert) => {
+        assert.expect(2);
+        class CustomDialog extends Component {}
+        CustomDialog.template = tags.xml`<RPCErrorDialog title="'Strange Error'"/>`;
+        CustomDialog.components = { RPCErrorDialog };
+        class NormalDialog extends Component {}
+        NormalDialog.template = tags.xml`<RPCErrorDialog title="'Normal Error'"/>`;
+        NormalDialog.components = { RPCErrorDialog };
+        const error = new RPCError();
+        error.code = 701;
+        error.message = "A normal error occured";
+        const errorData = {
+            context: { exception_class: "strange_error" },
+        };
+        error.exceptionName = "normal_error";
+        error.data = errorData;
+        function addDialog(dialogClass, props) {
+            assert.strictEqual(dialogClass, NormalDialog);
+            assert.deepEqual(props, {
+                name: "RPC_ERROR",
+                type: "server",
+                code: 701,
+                data: errorData,
+                subType: null,
+                message: "A normal error occured",
+                exceptionName: "normal_error",
+                traceback: error.stack,
+            });
+        }
+        serviceRegistry.add("dialog", makeFakeDialogService(addDialog), { force: true });
+        await makeTestEnv();
+        errorDialogRegistry.add("strange_error", CustomDialog);
+        errorDialogRegistry.add("normal_error", NormalDialog);
+        const errorEvent = new PromiseRejectionEvent("error", { reason: error, promise: null });
+        await unhandledRejectionCb(errorEvent);
+    }
+);
 QUnit.test("handle CONNECTION_LOST_ERROR", async (assert) => {
     patchWithCleanup(browser, {
         setTimeout: (callback, delay) => {
@@ -154,7 +196,6 @@ QUnit.test("handle CONNECTION_LOST_ERROR", async (assert) => {
         "create (Connection restored. You are back online.)",
     ]);
 });
-
 QUnit.test("will let handlers from the registry handle errors first", async (assert) => {
     errorHandlerRegistry.add("__test_handler__", (env, err, originalError) => {
         assert.strictEqual(originalError, error);
@@ -169,13 +210,11 @@ QUnit.test("will let handlers from the registry handle errors first", async (ass
     await unhandledRejectionCb(errorEvent);
     assert.verifySteps(["in handler"]);
 });
-
 QUnit.test("handle uncaught promise errors", async (assert) => {
     class TestError extends Error {}
     const error = new TestError();
     error.message = "This is an error test";
     error.name = "TestError";
-
     function addDialog(dialogClass, props) {
         assert.strictEqual(dialogClass, ClientErrorDialog);
         assert.deepEqual(props, {
@@ -186,17 +225,14 @@ QUnit.test("handle uncaught promise errors", async (assert) => {
     }
     serviceRegistry.add("dialog", makeFakeDialogService(addDialog), { force: true });
     await makeTestEnv();
-
     const errorEvent = new PromiseRejectionEvent("error", { reason: error, promise: null });
     await unhandledRejectionCb(errorEvent);
 });
-
 QUnit.test("handle uncaught client errors", async (assert) => {
     class TestError extends Error {}
     const error = new TestError();
     error.message = "This is an error test";
     error.name = "TestError";
-
     function addDialog(dialogClass, props) {
         assert.strictEqual(dialogClass, ClientErrorDialog);
         assert.strictEqual(props.name, "UncaughtClientError > TestError");
@@ -204,7 +240,6 @@ QUnit.test("handle uncaught client errors", async (assert) => {
     }
     serviceRegistry.add("dialog", makeFakeDialogService(addDialog), { force: true });
     await makeTestEnv();
-
     const errorEvent = new ErrorEvent("error", {
         error,
         colno: 1,
@@ -213,70 +248,54 @@ QUnit.test("handle uncaught client errors", async (assert) => {
     });
     await errorCb(errorEvent);
 });
-
 QUnit.test("handle uncaught CORS errors", async (assert) => {
     class TestError extends Error {}
     const error = new TestError();
     error.message = "This is a cors error";
     error.name = "CORS error";
-
     function addDialog(dialogClass, props) {
         assert.strictEqual(dialogClass, NetworkErrorDialog);
         assert.strictEqual(props.message, "Uncaught CORS Error");
     }
     serviceRegistry.add("dialog", makeFakeDialogService(addDialog), { force: true });
     await makeTestEnv();
-
     // CORS error event has no colno, no lineno and no filename
     const errorEvent = new ErrorEvent("error", { error });
     await errorCb(errorEvent);
 });
-
 QUnit.test("check retry", async (assert) => {
     assert.expect(3);
-
     errorHandlerRegistry.add("__test_handler__", () => {
         assert.step("dispatched");
     });
-
     const def = makeDeferred();
     patchWithCleanup(browser, {
         setTimeout(fn) {
             def.then(fn);
         },
     });
-
     serviceRegistry.remove("dialog");
     await makeTestEnv();
-
     class TestError extends Error {}
     const error = new TestError();
     error.message = "This is an error test";
     error.name = "TestError";
-
     const errorEvent = new PromiseRejectionEvent("error", { reason: error, promise: null });
     await unhandledRejectionCb(errorEvent);
-
     assert.verifySteps([]);
-
     serviceRegistry.add("dialog", dialogService);
     await nextTick();
-
     await def.resolve();
     assert.verifySteps(["dispatched"]);
 });
-
 QUnit.test("lazy loaded handlers", async (assert) => {
     await makeTestEnv();
     const errorEvent = new PromiseRejectionEvent("error", { reason: new Error(), promise: null });
-
     await unhandledRejectionCb(errorEvent);
     assert.verifySteps([]);
-
     errorHandlerRegistry.add("__test_handler__", () => {
         assert.step("in handler");
     });
-
     await unhandledRejectionCb(errorEvent);
     assert.verifySteps(["in handler"]);
 });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
 - Duplicate Product creation

Current behavior before PR:
 - System prompts only warning message when creating duplicate Product but it allows to save the Product.

Desired behavior after PR is merged:
- System won't allow saving of Duplicate Product Code.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
