### PR TITLE
send email  receipt in reprint screen

### DIFF
--- a/custom/fg_custom/models/FgCustomerMaster.py
+++ b/custom/fg_custom/models/FgCustomerMaster.py
@@ -26,7 +26,7 @@ class CustomerInherit(models.Model):
 
     currentDate = datetime.date.today()
 
-    @api.constrains('fg_birthdate')
+    @api.constrains('x_birthdate')
     def _check_value(self):
         if self.fg_birthdate >= self.currentDate:
             raise ValidationError(_('Birthdate should not be greater than current date.'))

--- a/custom/fg_custom/static/src/pos/js/FgEmailReceiptButton.js
+++ b/custom/fg_custom/static/src/pos/js/FgEmailReceiptButton.js
@@ -1,0 +1,111 @@
+odoo.define('fg_custom.FgEmailReceiptButton', function (require) {
+    'use strict';
+
+    const { useListener } = require('web.custom_hooks');
+    const PosComponent = require('point_of_sale.PosComponent');
+    const Registries = require('point_of_sale.Registries');
+    const { Printer } = require('point_of_sale.Printer');
+    const { useRef } = owl.hooks;
+
+    class FgEmailReceiptButton extends PosComponent {
+        constructor() {
+            super(...arguments);
+            this.orderReceipt = useRef('order-receipt');
+            this.props.inputEmail = this.props.inputEmail || (this.props.order.attributes.client && this.props.order.attributes.client.email) || '';
+
+        }
+        async emailReceipt() {
+            var email = this.props.inputEmail;
+            if(email){
+               try {
+                    await this._sendReceiptToCustomer(email);
+//                    this.props.order.emailSuccessful = true;
+//                    this.props.order.emailNotice = this.env._t('Email sent.');
+//                    this.showPopup('', {
+//                        title: this.env._t('Send Receipt'),
+//                        body: this.env._t(
+//                            'Email sent.'
+//                        ),
+//                    });
+                    return;
+                } catch (error) {
+//                    this.props.order.emailSuccessful = false;
+//                    this.props.order.emailNotice = this.env._t('Sending email failed. Please try again.');
+                    this.showPopup('ErrorPopup', {
+                        title: this.env._t('Send Receipt'),
+                        body: this.env._t(
+                            'Sending email failed. Please try again.'
+                        ),
+                    });
+                    return;
+                }
+            }else{
+                return;
+            }
+        }
+        async _sendReceiptToCustomer(email) {
+
+                const printer = new Printer(null, this.env.pos);
+                const receiptString = this.orderReceipt.comp.el.outerHTML;
+                const ticketImage = await printer.htmlToImg(receiptString);
+                const order = this.props.order;
+                const client = order.get_client();
+                const orderName = order.get_name();
+                const orderClient = { email: email, name: client ? client.name : email };
+                const order_server_id = this.props.order.backendId;
+                await this.rpc({
+                    model: 'pos.order',
+                    method: 'action_receipt_to_customer',
+                    args: [[order_server_id], orderName, orderClient, ticketImage],
+                });
+
+            }
+    }
+    FgEmailReceiptButton.template = 'FgEmailReceiptButton';
+    Registries.Component.add(FgEmailReceiptButton);
+
+    return FgEmailReceiptButton;
+});
+//
+//odoo.define('fg_custom.FgEmailReceiptButton', function (require) {
+//    'use strict';
+//
+//    const AbstractReceiptScreen = require('point_of_sale.AbstractReceiptScreen');
+//    const Registries = require('point_of_sale.Registries');
+//    const PosComponent = require('point_of_sale.PosComponent');
+//
+//    const FgEmailReceiptButton = (AbstractReceiptScreen) => {
+//        class FgEmailReceiptButton extends AbstractReceiptScreen {
+//            constructor() {
+//                super(...arguments);
+//            }
+//            mounted() {
+//                this.emailReceipt();
+//            }
+//            async emailReceipt() {
+//                console.log(this);
+//                console.log(this.order);
+//                console.log(this.orderUiState);
+////                if (!is_email(this.orderUiState.inputEmail)) {
+////                    this.orderUiState.emailSuccessful = false;
+////                    this.orderUiState.emailNotice = this.env._t('Invalid email.');
+////                    return;
+////                }
+////                try {
+////                    await this._sendReceiptToCustomer();
+////                    this.orderUiState.emailSuccessful = true;
+////                    this.orderUiState.emailNotice = this.env._t('Email sent.');
+////                } catch (error) {
+////                    this.orderUiState.emailSuccessful = false;
+////                    this.orderUiState.emailNotice = this.env._t('Sending email failed. Please try again.');
+////                }
+//            }
+//        }
+//        FgEmailReceiptButton.template = 'FgEmailReceiptButton';
+//        return FgEmailReceiptButton;
+//    };
+//    Registries.Component.addByExtending(FgEmailReceiptButton, AbstractReceiptScreen);
+//
+//    return FgEmailReceiptButton;
+//});
+

--- a/custom/fg_custom/static/src/pos/xml/Screens/ReprintReceiptScreen/FgEmailReceiptButton.xml
+++ b/custom/fg_custom/static/src/pos/xml/Screens/ReprintReceiptScreen/FgEmailReceiptButton.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+    <t t-name="FgEmailReceiptButton" owl="1">
+        <form t-on-submit.prevent="emailReceipt" class="send-email">
+
+            <div class="input-email" style="text-align:center">
+                <t t-if="props.order.attributes.client !== null ">
+                    <input type="email" placeholder="Email Receipt"   t-model="props.order.attributes.client.email" />
+                </t>
+                <t t-if="props.order.attributes.client == null">
+                    <input type="email" placeholder="Email Receipt"  t-model="props.inputEmail" />
+                </t>
+                <button class="button print" type="submit">Send</button>
+            </div>
+            <div class="pos-receipt-container">
+                <OrderReceipt order="props.order" t-ref="order-receipt" />
+            </div>
+        </form>
+    </t>
+</templates>

--- a/custom/fg_custom/static/src/pos/xml/Screens/ReprintReceiptScreen/FgReprintReceiptScreen.xml
+++ b/custom/fg_custom/static/src/pos/xml/Screens/ReprintReceiptScreen/FgReprintReceiptScreen.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="point_of_sale.template" xml:space="preserve">
+    <t t-name="ReprintReceiptScreen"  t-extend="ReprintReceiptScreen" t-inherit="point_of_sale.ReprintReceiptScreen" t-inherit-mode="extension"
+       owl="1">
+
+        <xpath expr="//div[@class='button print']" position="after" >
+                <FgEmailReceiptButton order="props.order"/>
+        </xpath>
+        <xpath expr="//div[@class='pos-receipt-container']" position="replace" >
+        </xpath>
+
+    </t>
+</templates>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR: no send email receipt in reprint receipt screen

Desired behavior after PR is merged: send email receipt will be available in reprint receipt screen




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
