### PR TITLE
additonal channels, printed receipt to be tagged as printed

### DIFF
--- a/custom/fg_custom/models/FgOrderImport.py
+++ b/custom/fg_custom/models/FgOrderImport.py
@@ -21,8 +21,12 @@ class PosOrderInherit(models.Model):
     x_ext_order_ref = fields.Char("External Order Ref")
     x_ext_source = fields.Char("Channel")
 
-
     x_receipt_note = fields.Char("Receipt Note")
+    x_receipt_printed = fields.Boolean("Is Receipt Printed")
+    x_receipt_printed_date = fields.Date("OR Printed Date")
+
+
+    x_receipt_printed_date = fields.Date("OR Printed Date")
 
 
 class FgImportOrders(models.TransientModel):

--- a/custom/fg_custom/static/src/pos/css/fg_custom.css
+++ b/custom/fg_custom/static/src/pos/css/fg_custom.css
@@ -1,6 +1,5 @@
 
 /** FgAddCheckDetailsPopup **/
-
 .fg-custom-pos-payment {
     display: flex;
     flex-flow: column;

--- a/custom/fg_custom/static/src/pos/js/FgPosReceipt.js
+++ b/custom/fg_custom/static/src/pos/js/FgPosReceipt.js
@@ -31,6 +31,8 @@ odoo.define('fg_custom.FgPosReceipt', function (require) {
                 x_receipt_note: this.x_receipt_note,
                 x_ext_source: this.x_ext_source,
                 x_ext_order_ref: this.x_ext_order_ref,
+                x_receipt_printed: this.x_receipt_printed,
+                x_receipt_printed_date: this.x_receipt_printed_date,
             });
             return json;
         },
@@ -39,12 +41,16 @@ odoo.define('fg_custom.FgPosReceipt', function (require) {
              this.x_receipt_note = json.x_receipt_note;
              this.x_ext_source = json.x_ext_source;
              this.x_ext_order_ref = json.x_ext_order_ref;
+             this.x_receipt_printed = json.x_receipt_printed;
+             this.x_receipt_printed_date = json.x_receipt_printed_date;
         },
         export_for_printing: function(){
             var receipt = super_ordermodel.export_for_printing.apply(this, arguments);
             receipt.x_receipt_note= this.x_receipt_note;
             receipt.x_ext_source= this.x_ext_source;
             receipt.x_ext_order_ref= this.x_ext_order_ref;
+            receipt.x_receipt_printed= this.x_receipt_printed;
+            receipt.x_receipt_printed_date= this.x_receipt_printed_date;
             return receipt;
 
         }

--- a/custom/fg_custom/static/src/pos/js/FgPosReceiptScreen.js
+++ b/custom/fg_custom/static/src/pos/js/FgPosReceiptScreen.js
@@ -1,0 +1,35 @@
+odoo.define('fg_custom.ReceiptScreen', function(require) {
+    'use strict';
+
+    const ReceiptScreen = require('point_of_sale.ReceiptScreen');
+    const Registries = require('point_of_sale.Registries');
+
+    var models = require('point_of_sale.models');
+
+    const _super_posmodel = models.PosModel.prototype;
+    const PosResReceiptScreen = ReceiptScreen =>
+        class extends ReceiptScreen {
+            /**
+             * @override
+             */
+
+            async printReceipt() {
+                var isPrinted = await super._printReceipt();
+                this.currentOrder._printed = false;
+                if(isPrinted && !this.currentOrder.x_receipt_printed){
+                    this.currentOrder.x_receipt_printed = true;
+                    this.currentOrder.trigger('change', this.currentOrder); // needed so that export_to_JSON gets triggered
+                    this.currentOrder.x_receipt_printed_date = new Date();
+                    this.render();
+                    this.currentOrder.save_to_db();
+                    this.env.pos.push_orders(this.currentOrder, {});
+                }
+            }
+        };
+
+    Registries.Component.extend(ReceiptScreen, PosResReceiptScreen);
+
+    return ReceiptScreen;
+});
+
+

--- a/custom/fg_custom/static/src/pos/js/FgPosReprintReceiptScreen.js
+++ b/custom/fg_custom/static/src/pos/js/FgPosReprintReceiptScreen.js
@@ -1,0 +1,33 @@
+odoo.define('fg_custom.ReprintReceiptScreen', function(require) {
+    'use strict';
+
+    const ReprintReceiptScreen = require('point_of_sale.ReprintReceiptScreen');
+    const Registries = require('point_of_sale.Registries');
+
+    var models = require('point_of_sale.models');
+
+    const _super_posmodel = models.PosModel.prototype;
+    const PosResReceiptScreen = ReprintReceiptScreen =>
+        class extends ReprintReceiptScreen {
+            /**
+             * @override
+             */
+            async tryReprint() {
+                var isPrinted = await super._printReceipt();
+                if(isPrinted && !this.props.order.x_receipt_printed){
+                    this.props.order.x_receipt_printed = true;
+                    this.props.order.x_receipt_printed_date = new Date();
+                    this.props.order.trigger('change', this.props.order); // needed so that export_to_JSON gets triggered
+                    this.render();
+                    this.props.order.save_to_db();
+                    this.env.pos.push_orders(this.props.order, {});
+                }
+            }
+        };
+
+    Registries.Component.extend(ReprintReceiptScreen, PosResReceiptScreen);
+
+    return ReprintReceiptScreen;
+});
+
+

--- a/custom/fg_custom/static/src/pos/xml/ControlButtons/FgChannelButton.xml
+++ b/custom/fg_custom/static/src/pos/xml/ControlButtons/FgChannelButton.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-
     <t t-name="FgChannelButton" owl="1">
         <span class="control-button">
             <div id="channelDiv">Select Channel</div>
         </span>
     </t>
-
 </templates>

--- a/custom/fg_custom/static/src/pos/xml/Popups/FgChannelPopup.xml
+++ b/custom/fg_custom/static/src/pos/xml/Popups/FgChannelPopup.xml
@@ -20,6 +20,10 @@
                                         <option value = "Shopee">Shopee</option>
                                         <option value = "Traders">Traders</option>
                                         <option value = "Website">Website</option>
+                                        <option value = "MetroMart">MetroMart</option>
+                                        <option value = "Grab">Grab</option>
+                                        <option value = "FoodPanda">FoodPanda</option>
+                                        <option value = "Pickaroo">Pickaroo</option>
                                     </select>
                                 </div>
                             </div>

--- a/custom/fg_custom/static/src/pos/xml/Screens/ReceiptScreen/FgOrderReceipt.xml
+++ b/custom/fg_custom/static/src/pos/xml/Screens/ReceiptScreen/FgOrderReceipt.xml
@@ -3,7 +3,14 @@
     <t t-name="OrderReceipt"  t-extend="OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension"
        owl="1">
 
-    	<xpath expr="//img[@class='pos-receipt-logo']" position="replace" />
+    	<xpath expr="//img[@class='pos-receipt-logo']" position="replace" >
+            <t t-if="receipt.x_receipt_printed">
+                <br/>
+                <div style="text-align:center"><b>RE-PRINT COPY</b></div>
+            </t>
+        </xpath>
+
+
 
         <xpath expr="//div[@class='pos-receipt-contact']" position="replace">
                 <div class="pos-receipt-contact">

--- a/custom/fg_custom/static/src/pos/xml/Screens/ReceiptScreen/FgReceiptScreen.xml
+++ b/custom/fg_custom/static/src/pos/xml/Screens/ReceiptScreen/FgReceiptScreen.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="point_of_sale.template" xml:space="preserve">
+    <t t-name="ReceiptScreen"  t-extend="ReceiptScreen" t-inherit="point_of_sale.ReceiptScreen" t-inherit-mode="extension"
+       owl="1">
+
+    	<xpath expr="//div[@class='pos-receipt-container']" position="replace">
+            <div class="pos-receipt-container">
+                <OrderReceipt order="currentOrder" t-ref="order-receipt" />
+            </div>
+        </xpath>
+    </t>
+</templates>

--- a/custom/fg_custom/static/src/pos/xml/Screens/ReprintReceiptScreen/FgEmailReceiptButton.xml
+++ b/custom/fg_custom/static/src/pos/xml/Screens/ReprintReceiptScreen/FgEmailReceiptButton.xml
@@ -13,9 +13,11 @@
                 </t>
                 <button class="button print" type="submit">Send</button>
             </div>
+
             <div class="pos-receipt-container">
                 <OrderReceipt order="props.order" t-ref="order-receipt" />
             </div>
+
         </form>
     </t>
 </templates>

--- a/custom/fg_custom/static/src/pos/xml/Screens/TicketScreen/FgTicketScreen.xml
+++ b/custom/fg_custom/static/src/pos/xml/Screens/TicketScreen/FgTicketScreen.xml
@@ -9,12 +9,13 @@
                             <div class="header-row">
                                 <div class="col start wide">Date</div>
                                 <div class="col start wide">Receipt Number</div>
-                                <div class="col start wide">External Order Ref</div>
-                                <div class="col start wide">Channel</div>
+                                <div class="col start narrow">External Order Ref</div>
+                                <div class="col start narrow">Channel</div>
                                 <div class="col start">Customer</div>
                                 <div class="col start wide" t-if="showCardholderName()">Cardholder Name</div>
                                 <div class="col start">Employee</div>
                                 <div class="col end">Total</div>
+                                <div class="col start narrow">OR Printed Date</div>
                                 <div class="col start narrow">Status</div>
                                 <div class="col center very-narrow" name="delete"></div>
                             </div>
@@ -26,10 +27,10 @@
                                     <div class="col start wide">
                                         <t t-esc="order.name"></t>
                                     </div>
-                                    <div class="col start wide">
+                                    <div class="col start narrow">
                                         <t t-if="order.x_ext_order_ref" t-esc="order.x_ext_order_ref"></t>
                                     </div>
-                                    <div class="col start wide">
+                                    <div class="col start narrow">
                                         <t t-if="order.x_ext_source" t-esc="order.x_ext_source"></t>
                                     </div>
                                     <div class="col start">
@@ -43,6 +44,9 @@
                                     </div>
                                     <div class="col end">
                                         <t t-esc="getTotal(order)"></t>
+                                    </div>
+                                    <div class="col start narrow">
+                                            <t t-if="order.x_receipt_printed_date" t-esc="order.x_receipt_printed_date"></t>
                                     </div>
                                     <div class="col start narrow">
                                         <t t-esc="getStatus(order)"></t>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:
Re-print copy label for reprinted receipts, date printed will be shown in orders list in pos, addtional channel



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
