### PR TITLE
refund and transaction series,  capture all details during reprint

### DIFF
--- a/custom/fg_custom/models/FgPosOrder.py
+++ b/custom/fg_custom/models/FgPosOrder.py
@@ -149,19 +149,33 @@ class PosOrder(models.Model):
             'x_ext_order_ref': order.x_ext_order_ref,
             'x_receipt_printed': order.x_receipt_printed,
             'x_receipt_printed_date': order.x_receipt_printed_date,
+            'pos_si_trans_reference': order.pos_si_trans_reference,
+            'pos_trans_reference': order.pos_trans_reference,
+            'pos_refund_si_reference': order.pos_refund_si_reference,
+            'pos_refunded_id': order.pos_refunded_id.pos_si_trans_reference,
             'website_order_id': order.website_order_id
         })
         return fields
 
+
+
     @api.model
     def _order_fields(self, order):
         fields = super(PosOrder, self)._order_fields(order)
+        refunded_order_id = False;
+        if order.get('pos_refunded_id', False):
+            refunded_order = self.env['pos.order'].search([('id', '=', order.pos_refunded_id),('active', '=', True)])
+            refunded_order_id = refunded_order.pos_si_trans_reference
         fields.update({
             'x_ext_source': order.get('x_ext_source', False),
             'x_ext_order_ref': order.get('x_ext_order_ref', False),
             'x_receipt_printed': order.get('x_receipt_printed', False),
             'x_receipt_printed_date': order.get('x_receipt_printed_date', False),
-            'website_order_id': order.get('website_order_id', False)
+            'pos_si_trans_reference': order.get('pos_si_trans_reference', False),
+            'pos_trans_reference':  order.get('pos_trans_reference', False),
+            'pos_refund_si_reference':  order.get('pos_refund_si_reference', False),
+            'website_order_id': order.get('website_order_id', False),
+            'pos_refunded_id': refunded_order_id
         })
         return fields
 

--- a/custom/fg_custom/static/src/pos/js/FgPosReceipt.js
+++ b/custom/fg_custom/static/src/pos/js/FgPosReceipt.js
@@ -33,6 +33,10 @@ odoo.define('fg_custom.FgPosReceipt', function (require) {
                 x_receipt_printed: this.x_receipt_printed,
                 x_receipt_printed_date: this.x_receipt_printed_date,
                 website_order_id: this.website_order_id,
+                pos_si_trans_reference: this.pos_si_trans_reference,
+                pos_trans_reference: this.pos_trans_reference,
+                pos_refund_si_reference: this.pos_refund_si_reference,
+                pos_refunded_id: this.pos_refunded_id,
             });
             return json;
         },
@@ -44,6 +48,11 @@ odoo.define('fg_custom.FgPosReceipt', function (require) {
              this.x_receipt_printed = json.x_receipt_printed;
              this.x_receipt_printed_date = json.x_receipt_printed_date;
              this.website_order_id = json.website_order_id;
+             this.pos_si_trans_reference = json.pos_si_trans_reference;
+             this.pos_trans_reference = json.pos_trans_reference;
+             this.pos_refund_si_reference = json.pos_refund_si_reference;
+             this.pos_refunded_id = json.pos_refunded_id;
+
         },
         export_for_printing: function(){
             var receipt = super_ordermodel.export_for_printing.apply(this, arguments);
@@ -53,6 +62,11 @@ odoo.define('fg_custom.FgPosReceipt', function (require) {
             receipt.x_receipt_printed= this.x_receipt_printed;
             receipt.x_receipt_printed_date= this.x_receipt_printed_date;
             receipt.website_order_id= this.website_order_id;
+            receipt.pos_si_trans_reference= this.pos_si_trans_reference;
+            receipt.pos_trans_reference= this.pos_trans_reference;
+            receipt.pos_refund_si_reference= this.pos_refund_si_reference;
+            receipt.pos_refunded_id= this.pos_refunded_id;
+
             var val = {};
             _.each(receipt.orderlines, function(line){
                 if(line.program_id && line.is_program_reward){

--- a/custom/fg_custom/static/src/pos/js/screen_extend.js
+++ b/custom/fg_custom/static/src/pos/js/screen_extend.js
@@ -12,7 +12,10 @@ odoo.define('fg_custom.order_screen', function(require) {
                 var order = this.env.pos.get_order();
                 var old_name = order.name
                 const data = await this._getSiTransSequence(old_name);
-                this._receiptEnv.receipt.pos_si_trans_reference = data;
+                this._receiptEnv.receipt.pos_trans_reference = data.pos_trans_reference;
+                this._receiptEnv.receipt.pos_si_trans_reference = data.pos_si_trans_reference;
+                this._receiptEnv.receipt.pos_refund_si_reference = data.pos_refund_si_reference;
+                this._receiptEnv.receipt.pos_refunded_id = data.pos_refunded_id;
             }
 
             async _getSiTransSequence(name) {

--- a/custom/fg_custom/static/src/pos/xml/Screens/ReceiptScreen/FgOrderReceipt.xml
+++ b/custom/fg_custom/static/src/pos/xml/Screens/ReceiptScreen/FgOrderReceipt.xml
@@ -135,9 +135,10 @@
                             <t t-set="t_per_lines" t-value="line.price_with_tax_before_discount - line.price_with_tax"/>
                             <t t-set="total_discount_percentage" t-value="total_discount_percentage + t_per_lines"/>
                         </t>
-                        <t t-if="line.price_display >= 0 and !line.is_program_reward">
+<!--                        <t t-if="line.price_display >= 0 and !line.is_program_reward">-->
+                        <t t-if="!line.is_program_reward">
                             <t t-set="total_vat" t-value="total_vat + line.tax"/>
-                            <t t-set="total_qty" t-value="total_qty + line.quantity"/>
+                            <t t-set="total_qty" t-value="total_qty + Math.abs(line.quantity)"/>
                             <t t-set="price_discount" t-value="line.price_with_tax_before_discount - line.price_with_tax"/>
                             <t t-set="total_amt" t-value="total_amt + line.price_with_tax + price_discount"/>
                             <t t-set="is_non_zero_vat" t-value="''"/>
@@ -252,10 +253,18 @@
                 </div>
 
                 <div t-if="receipt.name" class="transaction" style="margin-top: 8%;font-size: 75%;">
-                    <span class="pos-receipt-left-align"><b>Trans# </b> <t t-esc="receipt.pos_si_trans_reference"/></span>
+                    <span class="pos-receipt-left-align"><b>Trans# </b> <t t-esc="receipt.pos_trans_reference"/></span>
                 </div>
-                <div t-if="receipt.name" class="sale_invoice" style="font-size: 75%;">
-                    <span class="pos-receipt-left-align"><b>SI# </b> <t t-esc="receipt.pos_si_trans_reference"/></span>
+                <div t-if="receipt.pos_refunded_id" class="sale_invoice" style="font-size: 75%;">
+                    <span  class="pos-receipt-left-align"><b>Reference SI# </b> <t t-esc="receipt.pos_refunded_id"/></span>
+                </div>
+
+                <div t-if="receipt.pos_refunded_id" class="sale_invoice" style="font-size: 75%;">
+                    <span  class="pos-receipt-left-align"><b>Refund SI# </b> <t t-esc="receipt.pos_refund_si_reference"/></span>
+                </div>
+
+                <div t-if="!receipt.pos_refunded_id" class="sale_invoice" style="font-size: 75%;">
+                    <span  class="pos-receipt-left-align"><b>SI# </b> <t t-esc="receipt.pos_si_trans_reference"/></span>
                 </div>
 
                 <div t-if="m_t_d > 0" class="total_discount" style="margin-top: 8%;font-size: 75%;">
@@ -263,34 +272,34 @@
                     <span class="pos-receipt-right-align"><t t-esc="env.pos.format_currency_no_symbol(m_t_d)"/></span>
                 </div>
 
-                <div class="customer_information" style="margin-top: 8%;font-size: 75%;">
-                    <div style="overflow: hidden;">********************************************************</div>
-                    <div>
-                        <span class="pos-receipt-left-align"><b>Order #</b> <t t-esc="receipt.website_order_id"/> </span>
-                    </div>
-                    <div>
-                        <div>
-                            <span class="pos-receipt-left-align"><b>Name: </b></span>
-                            <span t-if="receipt.client and receipt.client.name" class="pos-receipt-left-align"> <t t-esc="receipt.client.name"/></span>
-                            <span t-else="" class="pos-receipt-right-align" style="width: 70%;overflow: hidden;">_______________________________________________</span>
-                        </div>
-                    </div>
-                    <div>
-                        <div>
-                            <span class="pos-receipt-left-align"><b>Phone: </b></span>
-                            <span t-if="receipt.client and receipt.client.phone" class="pos-receipt-left-align"> <t t-esc="receipt.client.phone"/></span>
-                            <span t-else="" class="pos-receipt-right-align" style="width: 70%;overflow: hidden;">_______________________________________________</span>
-                        </div>
-                    </div>
-                    <div>
-                        <div>
-                            <span class="pos-receipt-left-align"><b>Address: </b></span>
-                            <span t-if="receipt.client and receipt.client.address" class="pos-receipt-left-align"> <t t-esc="receipt.client.address"/></span>
-                            <span t-else="" class="pos-receipt-right-align" style="width: 70%;overflow: hidden;">_______________________________________________</span>
-                        </div>
-                    </div>
+<!--                <div class="customer_information" style="margin-top: 8%;font-size: 75%;">-->
+<!--                    <div style="overflow: hidden;">********************************************************</div>-->
+<!--                    <div>-->
+<!--                        <span class="pos-receipt-left-align"><b>Order #</b> <t t-esc="receipt.website_order_id"/> </span>-->
+<!--                    </div>-->
+<!--                    <div>-->
+<!--                        <div>-->
+<!--                            <span class="pos-receipt-left-align"><b>Name: </b></span>-->
+<!--                            <span t-if="receipt.client and receipt.client.name" class="pos-receipt-left-align"> <t t-esc="receipt.client.name"/></span>-->
+<!--                            <span t-else="" class="pos-receipt-right-align" style="width: 70%;overflow: hidden;">_______________________________________________</span>-->
+<!--                        </div>-->
+<!--                    </div>-->
+<!--                    <div>-->
+<!--                        <div>-->
+<!--                            <span class="pos-receipt-left-align"><b>Phone: </b></span>-->
+<!--                            <span t-if="receipt.client and receipt.client.phone" class="pos-receipt-left-align"> <t t-esc="receipt.client.phone"/></span>-->
+<!--                            <span t-else="" class="pos-receipt-right-align" style="width: 70%;overflow: hidden;">_______________________________________________</span>-->
+<!--                        </div>-->
+<!--                    </div>-->
+<!--                    <div>-->
+<!--                        <div>-->
+<!--                            <span class="pos-receipt-left-align"><b>Address: </b></span>-->
+<!--                            <span t-if="receipt.client and receipt.client.address" class="pos-receipt-left-align"> <t t-esc="receipt.client.address"/></span>-->
+<!--                            <span t-else="" class="pos-receipt-right-align" style="width: 70%;overflow: hidden;">_______________________________________________</span>-->
+<!--                        </div>-->
+<!--                    </div>-->
                     <div style="overflow: hidden;margin-top: 2%;">********************************************************</div>
-                </div>
+<!--                </div>-->
 
                 <div class="customer_details" style="margin-top: 8%;font-size: 75%;">
                     <div>
@@ -475,7 +484,7 @@
     <t t-name="OrderLinesReceipt" t-extend="OrderLinesReceipt" t-inherit="point_of_sale.OrderLinesReceipt" t-inherit-mode="extension" owl="1">
         <xpath expr="//t[@t-foreach='receipt.orderlines']" position="replace">
             <t t-foreach="receipt.orderlines" t-as="line" t-key="line.id">
-                <t t-if="line.price_display >= 0 and !line.is_program_reward">
+                <t t-if="line.price_display_one >= 0 and !line.is_program_reward">
                     <div class="responsive-price">
                         <span t-esc="line.quantity" style="margin-right: 5%;" class="pos-receipt-left-align"/>
                         <span t-esc="line.product_name" class="pos-receipt-left-align"/>

--- a/custom/fg_custom/views/point_of_sale_sequence.xml
+++ b/custom/fg_custom/views/point_of_sale_sequence.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <record id="seq_pos_si_trans" model="ir.sequence">
-            <field name="name">Si/Trans Receipt Number</field>
+            <field name="name">SI Receipt Number</field>
             <field name="code">pos.order.si.tra</field>
             <field name="padding">8</field>
             <field name="number_increment">1</field>
@@ -11,6 +11,27 @@
         </record>
     </data>
 
+    <data noupdate="1">
+        <record id="seq_pos_trans" model="ir.sequence">
+            <field name="name">Trans Receipt Number for Refund</field>
+            <field name="code">pos.order.si.tra</field>
+            <field name="padding">8</field>
+            <field name="number_increment">1</field>
+            <field name="number_next_actual">1</field>
+            <field name="company_id" eval="False" />
+        </record>
+    </data>
+
+    <data noupdate="1">
+        <record id="seq_pos_refund_si" model="ir.sequence">
+            <field name="name">Trans Receipt Number for Refund</field>
+            <field name="code">pos.order.si.tra</field>
+            <field name="padding">8</field>
+            <field name="number_increment">1</field>
+            <field name="number_next_actual">1</field>
+            <field name="company_id" eval="False" />
+        </record>
+    </data>
 
 <!--    change page title-->
     <template id="web_layout_title_pogi" name="change title" inherit_id="web.layout">


### PR DESCRIPTION
Description of the issue/feature this PR addresses: refund and transaction series; capture all details during reprint

Current behavior before PR: no refund series, transaction series is shared with SI series

Desired behavior after PR is merged:

refund and transaction series; capture all details during reprint


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
