### PR TITLE
Remove Quotation/Order Button in POS

### DIFF
--- a/custom/fg_custom/__manifest__.py
+++ b/custom/fg_custom/__manifest__.py
@@ -7,7 +7,7 @@
     'description': """
     Pilmico custom addons
         """,
-    'depends': ['product', 'account', 'point_of_sale', 'base', 'sale', 'pos_coupon'],
+    'depends': ['product', 'account', 'point_of_sale', 'base', 'sale', 'pos_coupon','pos_sale'],
     'data': [
         'security/groups.xml',
         'views/FgOrderDetails.xml',

--- a/custom/fg_custom/static/src/pos/xml/ControlButtons/FgQuotationBtn.xml
+++ b/custom/fg_custom/static/src/pos/xml/ControlButtons/FgQuotationBtn.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="pos_sale.template" xml:space="preserve">
+    <t t-extend="SetSaleOrderButton" t-name="SetSaleOrderButton" t-inherit="pos_sale.SetSaleOrderButton" t-inherit-mode="extension"
+       owl="1">
+    <t t-name="SetSaleOrderButton" owl="1">
+        <xpath expr="//div[hasclass('control-button')]" position="attributes"></xpath>
+    </t>
+</t>
+</templates>


### PR DESCRIPTION
Remove Quotation/Order Button in POS

Description of the issue/feature this PR addresses:

Current behavior before PR: Quotation/Order Button is visible in POS

Desired behavior after PR is merged:
Remove/Hide Quotation/Order Button in POS


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
