### PR TITLE
Remove email receipt option in pos

### DIFF
--- a/custom/fg_custom/static/src/pos/xml/Screens/ReceiptScreen/FgReceiptScreen.xml
+++ b/custom/fg_custom/static/src/pos/xml/Screens/ReceiptScreen/FgReceiptScreen.xml
@@ -8,5 +8,9 @@
                 <OrderReceipt order="currentOrder" t-ref="order-receipt" />
             </div>
         </xpath>
+
+<!--        hide email receipt option in receipt-->
+        <xpath expr="//div[@class='input-email']" position="replace"></xpath>
+
     </t>
 </templates>

--- a/custom/fg_custom/static/src/pos/xml/Screens/ReprintReceiptScreen/FgEmailReceiptButton.xml
+++ b/custom/fg_custom/static/src/pos/xml/Screens/ReprintReceiptScreen/FgEmailReceiptButton.xml
@@ -4,15 +4,15 @@
     <t t-name="FgEmailReceiptButton" owl="1">
         <form t-on-submit.prevent="emailReceipt" class="send-email">
 
-            <div class="input-email" style="text-align:center">
-                <t t-if="props.order.attributes.client !== null ">
-                    <input type="email" placeholder="Email Receipt"   t-model="props.order.attributes.client.email" />
-                </t>
-                <t t-if="props.order.attributes.client == null">
-                    <input type="email" placeholder="Email Receipt"  t-model="props.inputEmail" />
-                </t>
-                <button class="button print" type="submit">Send</button>
-            </div>
+<!--            <div class="input-email" style="text-align:center">-->
+<!--                <t t-if="props.order.attributes.client !== null ">-->
+<!--                    <input type="email" placeholder="Email Receipt"   t-model="props.order.attributes.client.email" />-->
+<!--                </t>-->
+<!--                <t t-if="props.order.attributes.client == null">-->
+<!--                    <input type="email" placeholder="Email Receipt"  t-model="props.inputEmail" />-->
+<!--                </t>-->
+<!--                <button class="button print" type="submit">Send</button>-->
+<!--            </div>-->
 
             <div class="pos-receipt-container">
                 <OrderReceipt order="props.order" t-ref="order-receipt" />


### PR DESCRIPTION
Remove email receipt option in pos

Description of the issue/feature this PR addresses:

Current behavior before PR: Email option is enable

Desired behavior after PR is merged:
 Email option should be removed


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
