### PR TITLE
BITS 35 - SD and PWD validation during order transaction

### DIFF
--- a/custom/fg_custom/models/pos_config.py
+++ b/custom/fg_custom/models/pos_config.py
@@ -6,13 +6,13 @@ class FgPosConfig(models.Model):
     _inherit = "pos.config"
 
     def use_coupon_code(self, code, creation_date, partner_id, reserved_program_ids):
-        if not partner_id:
-            return {
-                "successful": False,
-                "payload": {
-                    "error_message": _("This order not available customer, first set custom.")
-                },
-            }
+        # if not partner_id:
+        #     return {
+        #         "successful": False,
+        #         "payload": {
+        #             "error_message": _("This order not available customer, first set custom.")
+        #         },
+        #     }
         coupon_to_check = self.env["coupon.coupon"].search(
             [("code", "=", code), ("program_id", "in", self.program_ids.ids)]
         )

--- a/custom/fg_custom/static/src/pos/js/FgPosReceipt.js
+++ b/custom/fg_custom/static/src/pos/js/FgPosReceipt.js
@@ -112,29 +112,30 @@ odoo.define('fg_custom.FgPosReceipt', function (require) {
                 const customer = this.get_client();
                 if(!customer){
 //                    Gui.showNotification('This order not available customer, first set custom.');
-                    Gui.showPopup('ErrorPopup', {
-                        title: _t("Set customer"),
-                        body: _t("This order not available customer, first set custom"),
-                    });
-                    return;
-                }
-                if(promoProgram.fg_discount_type){
-                    if(promoProgram.fg_discount_type == 'is_pwd_discount' && !customer.x_pwd_id){
-//                        Gui.showNotification('PWD ID not set on customer, first set custom.');
-                        Gui.showPopup('ErrorPopup', {
-                            title: _t("Set Discount"),
-                            body: _t("PWD ID not set on customer, first set custom."),
-                        });
-                        return;
-                    }
-                    if(promoProgram.fg_discount_type == 'is_senior_discount' && !customer.x_senior_id){
-//                        Gui.showNotification('Senior ID not set on customer, first set custom.');
-                        Gui.showPopup('ErrorPopup', {
-                            title: _t("Set Discount"),
-                            body: _t("Senior ID not set on customer, first set custom."),
-                        });
-                        return;
-                    }
+//                    Gui.showPopup('ErrorPopup', {
+//                        title: _t("Set customer"),
+//                        body: _t("This order not available customer, first set custom"),
+//                    });
+//                    return;
+
+//                    if(promoProgram.fg_discount_type){
+//                        if(promoProgram.fg_discount_type == 'is_pwd_discount' && !customer.x_pwd_id){
+//    //                        Gui.showNotification('PWD ID not set on customer, first set custom.');
+//                            Gui.showPopup('ErrorPopup', {
+//                                title: _t("Set Discount"),
+//                                body: _t("PWD ID not set on customer, first set custom."),
+//                            });
+//                            return;
+//                        }
+//                        if(promoProgram.fg_discount_type == 'is_senior_discount' && !customer.x_senior_id){
+//    //                        Gui.showNotification('Senior ID not set on customer, first set custom.');
+//                            Gui.showPopup('ErrorPopup', {
+//                                title: _t("Set Discount"),
+//                                body: _t("Senior ID not set on customer, first set custom."),
+//                            });
+//                            return;
+//                        }
+//                    }
                 }
                 // TODO these two operations should be atomic
                 this.activePromoProgramIds.push(promoProgram.id);

--- a/custom/fg_custom/static/src/pos/js/ProductScreen.js
+++ b/custom/fg_custom/static/src/pos/js/ProductScreen.js
@@ -11,21 +11,29 @@ odoo.define('fg_custom.ProductScreen', function(require) {
                 var order = this.env.pos.get_order();
                 const currentClient = order.get_client();
                 var lines_to_recompute = false;
+                var discount_type='';
+                var errorMsg='Customer is required and PWD ID of the customer must be filled out for this transaction';
                 if(order.rewardsContainer && order.rewardsContainer._rewards){
                     _.each(order.rewardsContainer._rewards, function (line) {
                         if(line && line[0] && line[0].program && line[0].program.fg_discount_type){
                             if(line[0].program.fg_discount_type == 'is_pwd_discount' || line[0].program.fg_discount_type == 'is_senior_discount'){
                                 lines_to_recompute = true;
+                                discount_type = line[0].program.fg_discount_type;
                             }
                         }
                     });
                 }
                 if(lines_to_recompute){
-                    if (currentClient) {
-                    }else{
+                    var errorMessage='';
+                    if(discount_type=='is_senior_discount' && (currentClient==null || !currentClient.x_senior_id || currentClient.x_senior_id=='')){
+                        errorMessage='Customer is required and Senior Citizen ID of the customer must be filled out for this transaction.'
+                    }else if(discount_type=='is_pwd_discount' && (currentClient==null || !currentClient.x_pwd_id || currentClient.x_pwd_id=='')){
+                        errorMessage='Customer is required and PWD ID of the customer must be filled out for this transaction.'
+                    }
+                    if (errorMessage!='') {
                         this.showPopup('ErrorPopup', {
-                            title: this.env._t("Set customer"),
-                            body: this.env._t("This order not available customer, discount line available on order"),
+                            title: this.env._t("Validate Customer"),
+                            body: this.env._t(errorMessage),
                         });
                         return;
                     }

--- a/custom/fg_custom/static/src/pos/js/PromoCodeButton.js
+++ b/custom/fg_custom/static/src/pos/js/PromoCodeButton.js
@@ -8,14 +8,14 @@ odoo.define('fg_custom.PromoCodeButton', function(require) {
         class extends PromoCodeButton {
             async onClick() {
                 const currentClient = this.env.pos.get_order().get_client();
-                if (currentClient) {
-                }else{
-                    this.showPopup('ErrorPopup', {
-                        title: this.env._t("Set customer"),
-                        body: this.env._t("This order not available customer, first set custom"),
-                    });
-                    return;
-                }
+//                if (currentClient) {
+//                }else{
+//                    this.showPopup('ErrorPopup', {
+//                        title: this.env._t("Set customer"),
+//                        body: this.env._t("This order not available customer, first set custom"),
+//                    });
+//                    return;
+//                }
                 await super.onClick();
             }
         };


### PR DESCRIPTION
Required SC/PWD name and ID if with PWD/SC discounts, should not go through if no SC/PWD name and ID are not provided

Description of the issue/feature this PR addresses: 

Current behavior before PR: customer is required even though coupon is not for Senior or PWD

Desired behavior after PR is merged: should allow other coupons even if customer is empty




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
