### PR TITLE
Fix the display of discount in receipt reprint

### DIFF
--- a/custom/fg_custom/static/src/pos/js/FgPosReceipt.js
+++ b/custom/fg_custom/static/src/pos/js/FgPosReceipt.js
@@ -105,7 +105,6 @@ odoo.define('fg_custom.FgPosReceipt', function (require) {
                     }
                 }
             });
-//            console.log('Receipt', receipt);
             receipt.program_reward_lines = val;
             return receipt;
         },

--- a/custom/fg_custom/static/src/pos/js/FgPosReceipt.js
+++ b/custom/fg_custom/static/src/pos/js/FgPosReceipt.js
@@ -99,12 +99,13 @@ odoo.define('fg_custom.FgPosReceipt', function (require) {
                     }
                 }else{
                     if(line.price < 0 ){ // to display discount in the pos reprinting
+                        line.is_program_reward = true; // set field to true for discount/promo items
                         total_disc_amt = total_disc_amt + Math.abs(line.price_with_tax);
                         val[line.program_id] = [line.product_name , total_disc_amt]
                     }
                 }
             });
-
+//            console.log('Receipt', receipt);
             receipt.program_reward_lines = val;
             return receipt;
         },

--- a/custom/fg_custom/static/src/pos/xml/Screens/ReceiptScreen/FgOrderReceipt.xml
+++ b/custom/fg_custom/static/src/pos/xml/Screens/ReceiptScreen/FgOrderReceipt.xml
@@ -152,8 +152,8 @@
                             <t t-set="t_per_lines" t-value="line.price_with_tax_before_discount - line.price_with_tax"/>
                             <t t-set="total_discount_percentage" t-value="total_discount_percentage + t_per_lines"/>
                         </t>
-<!--                        <t t-if="line.price_display >= 0 and !line.is_program_reward">-->
-                        <t t-if="!line.is_program_reward and line.product_name !='Discount'">
+                        <t t-if="line.price_display >= 0 and !line.is_program_reward">
+<!--                        <t t-if="!line.is_program_reward and line.product_name !='Discount'">-->
                             <t t-set="total_vat" t-value="total_vat + line.tax"/>
                             <t t-set="total_qty" t-value="total_qty + Math.abs(line.quantity)"/>
                             <t t-set="price_discount" t-value="line.price_with_tax_before_discount - line.price_with_tax"/>
@@ -174,6 +174,7 @@
                             </t>
                         </t>
                         <t t-else="">
+<!--                            <div> <span>**** Promo Discount ****</span> </div>-->
                             <t t-set="total_vat" t-value="total_vat + line.tax"/>
                             <t t-if="line.is_program_reward">
                                 <t t-set="total_discount_coupon_minus" t-value="total_discount_coupon_minus + Math.abs(line.price_with_tax)"/>


### PR DESCRIPTION
Fix the display of discount in receipt reprint
  - issue: no of items is doubled and total amount is less of discount

Description of the issue/feature this PR addresses:

Current behavior before PR:
   no of items is doubled and total amount is less of discount
Desired behavior after PR is merged:
   Fix the display of discount in receipt reprint



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
